### PR TITLE
feat: AI 서버에 데이터 요청 및 응답 구현

### DIFF
--- a/src/main/java/capston/busthecall/controller/BusArrivalInfoController.java
+++ b/src/main/java/capston/busthecall/controller/BusArrivalInfoController.java
@@ -1,11 +1,9 @@
 package capston.busthecall.controller;
 
 import capston.busthecall.domain.dto.response.BusArrivalInfo;
+import capston.busthecall.manager.AIManager;
 import capston.busthecall.manager.OpenApiManager;
-import capston.busthecall.repository.BeaconRepository;
-import capston.busthecall.security.token.TokenResolver;
 import capston.busthecall.service.BeaconService;
-import capston.busthecall.service.BusService;
 import capston.busthecall.support.ApiResponse;
 import capston.busthecall.support.ApiResponseGenerator;
 import lombok.RequiredArgsConstructor;
@@ -13,8 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-import jakarta.servlet.http.HttpServletRequest;
-import java.io.UnsupportedEncodingException;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -25,14 +21,17 @@ public class BusArrivalInfoController {
 
     private final OpenApiManager openApiManager;
     private final BeaconService beaconService;
-    private final BusService busService;
+    private final AIManager aiManager;
 
     @GetMapping("/{uuId}")
     public ApiResponse<ApiResponse.SuccessBody<List<BusArrivalInfo>>> getBusArrivalInfo(@PathVariable("uuId") String uuId) {
         try {
             Long stationId = beaconService.excute(uuId);
             List<BusArrivalInfo> busArrivalInfos = openApiManager.fetch(stationId);
-            return ApiResponseGenerator.success(busArrivalInfos, HttpStatus.OK);
+            List<BusArrivalInfo> updateBusArrivalInfos = aiManager.predictTime(busArrivalInfos,
+                    beaconService.findOne(stationId).getStationName());
+
+            return ApiResponseGenerator.success(updateBusArrivalInfos, HttpStatus.OK);
         } catch (Exception e) {
             log.error("Error fetching bus arrival information", e);
             return null;

--- a/src/main/java/capston/busthecall/domain/Beacon.java
+++ b/src/main/java/capston/busthecall/domain/Beacon.java
@@ -13,8 +13,7 @@ public class Beacon {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name ="beaconId")
     private Long id;
-
     private String uuId;
-
     private Long stationId;
+    private String stationName;
 }

--- a/src/main/java/capston/busthecall/domain/dto/request/PredictTimeRequestDto.java
+++ b/src/main/java/capston/busthecall/domain/dto/request/PredictTimeRequestDto.java
@@ -1,0 +1,21 @@
+package capston.busthecall.domain.dto.request;
+
+import capston.busthecall.domain.dto.response.RouteBusStopListResponse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PredictTimeRequestDto {
+
+    private String routeName;
+    private String startBusStopName;
+    private String arrivalBusStopName;
+    private List<RouteBusStopListResponse> routeInfos;
+}

--- a/src/main/java/capston/busthecall/domain/dto/response/BusArrivalInfo.java
+++ b/src/main/java/capston/busthecall/domain/dto/response/BusArrivalInfo.java
@@ -1,6 +1,5 @@
 package capston.busthecall.domain.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,6 +10,7 @@ import lombok.NoArgsConstructor;
 public class BusArrivalInfo {
     private Long busId;
     private int remainStop;
+    private Long nowBusStopId;
     private String busstopName;
 
     private String shortLineName;
@@ -21,9 +21,10 @@ public class BusArrivalInfo {
 
     private int arriveFlag;
     @Builder
-    public BusArrivalInfo(Long busId, int remainStop, String busstopName, String shortLineName, Long remainMin, Long lineId, int arriveFlag) {
+    public BusArrivalInfo(Long busId, int remainStop, Long nowBusStopId, String busstopName, String shortLineName, Long remainMin, Long lineId, int arriveFlag) {
         this.busId = busId;
         this.remainStop = remainStop;
+        this.nowBusStopId = nowBusStopId;
         this.busstopName = busstopName;
         this.shortLineName = shortLineName;
         this.remainMin = remainMin;

--- a/src/main/java/capston/busthecall/domain/dto/response/PredictTimeResponseDto.java
+++ b/src/main/java/capston/busthecall/domain/dto/response/PredictTimeResponseDto.java
@@ -1,0 +1,15 @@
+package capston.busthecall.domain.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PredictTimeResponseDto {
+
+    private Long operationTime;
+}

--- a/src/main/java/capston/busthecall/exception/ErrorCode.java
+++ b/src/main/java/capston/busthecall/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     MULTI_ROLE_IN_EMAIL(HttpStatus.BAD_REQUEST, "이 이메일은 다중 회원입니다."),
     NOT_FOUND_RESERVATION(HttpStatus.NOT_FOUND, "not exist reservation"),
     NOT_FOUND_OPERATING_BUS(HttpStatus.UNAUTHORIZED, "not operating bus"),
+    PREDICT_TIME_REQUEST_ERROR(HttpStatus.CONFLICT, "predict time error"),
     ROUTE_ENCODING_ERROR(HttpStatus.CONFLICT, "route encoding error"),
     ROUTE_NOT_EXIST(HttpStatus.BAD_REQUEST, "route does not exist"),
     BUS_ENCODING_ERROR(HttpStatus.CONFLICT, "bus api encoding error"),

--- a/src/main/java/capston/busthecall/manager/AIManager.java
+++ b/src/main/java/capston/busthecall/manager/AIManager.java
@@ -1,0 +1,138 @@
+package capston.busthecall.manager;
+
+import capston.busthecall.domain.dto.request.PredictTimeRequestDto;
+import capston.busthecall.domain.dto.response.BusArrivalInfo;
+import capston.busthecall.domain.dto.response.PredictTimeResponseDto;
+import capston.busthecall.domain.dto.response.RouteBusStopListResponse;
+import capston.busthecall.route.RouteApiManager;
+import capston.busthecall.service.RouteService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+public class AIManager {
+
+    private final String pythonURL;
+    private final ObjectMapper objectMapper;
+    private final RouteService routeService;
+    private final RouteApiManager routeApiManager;
+
+    public AIManager(@Value("${python}") String url, ObjectMapper objectMapper
+            , RouteService routeService, RouteApiManager routeApiManager) {
+        pythonURL = url;
+        this.objectMapper = objectMapper;
+        this.routeService = routeService;
+        this.routeApiManager = routeApiManager;
+    }
+
+    public List<BusArrivalInfo> predictTime(List<BusArrivalInfo> infos, String arrivalBusStopName) {
+
+        try {
+            return createResponse(infos, sendToPythonServer(infos, arrivalBusStopName));
+        } catch (Exception e) {
+            log.info("predictTime Error", e);
+            return infos;
+        }
+    }
+
+    private List<BusArrivalInfo> createResponse(List<BusArrivalInfo> infos, PredictTimeResponseDto dto) {
+        BusArrivalInfo busInfo = getWantBusInfo(infos);
+        infos.remove(busInfo);
+        infos.add(updateBusInfo(busInfo, dto));
+        return infos;
+    }
+
+    private BusArrivalInfo updateBusInfo(BusArrivalInfo info, PredictTimeResponseDto dto) {
+        return BusArrivalInfo.builder()
+                .busId(info.getBusId())
+                .remainStop(info.getRemainStop())
+                .busstopName(info.getBusstopName())
+                .shortLineName(info.getShortLineName())
+                .remainMin(calculateRemainMin(info.getRemainMin(), dto))
+                .lineId(info.getLineId())
+                .arriveFlag(info.getArriveFlag())
+                .build();
+    }
+
+    private Long calculateRemainMin(Long remainMin, PredictTimeResponseDto dto) {
+        return remainMin * 60 - dto.getOperationTime();
+    }
+
+    private PredictTimeResponseDto sendToPythonServer(List<BusArrivalInfo> infos, String arrivalBusStopName) throws JsonProcessingException {
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        BusArrivalInfo busInfo = getWantBusInfo(infos);
+
+        String data = objectMapper.writeValueAsString(createRequestDto(
+                getWantStationList(routeApiManager.busStopList(
+                        routeService.findOne(busInfo.getShortLineName()
+                        )
+                ), busInfo, arrivalBusStopName)
+                , busInfo, arrivalBusStopName));
+        log.info("Predict Time data = {}", data);
+
+        HttpEntity<String> entity = new HttpEntity<>(data, headers);
+        log.info("request entity : {}", entity);
+        return restTemplate.postForObject(pythonURL, entity, PredictTimeResponseDto.class);
+    }
+
+    private List<RouteBusStopListResponse> getWantStationList(List<RouteBusStopListResponse> list, BusArrivalInfo busInfo, String arrivalBusStopName) {
+        boolean checking = false;
+
+        return makeStationList(list, busInfo, arrivalBusStopName, checking);
+    }
+
+    private List<RouteBusStopListResponse> makeStationList(List<RouteBusStopListResponse> list, BusArrivalInfo busInfo, String arrivalBusStopName, boolean checking) {
+        List<RouteBusStopListResponse> result = new ArrayList<>();
+
+        for (RouteBusStopListResponse busStop : list) {
+            if (!checking) {
+                if (busInfo.getNowBusStopId().equals(busStop.getBusStopId())) {
+                    result.add(busStop);
+                    checking = true;
+                }
+            } else {
+                result.add(busStop);
+
+                if (busStop.getBusStopName().equals(arrivalBusStopName)) {
+                    break;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private BusArrivalInfo getWantBusInfo(List<BusArrivalInfo> infos) {
+        BusArrivalInfo busInfo = new BusArrivalInfo();
+        for (BusArrivalInfo info : infos) {
+            if (info.getShortLineName().equals("진월07")) {
+                busInfo = info;
+            }
+        }
+        return busInfo;
+    }
+
+    private PredictTimeRequestDto createRequestDto(List<RouteBusStopListResponse> list, BusArrivalInfo info, String arrivalBusStopName) {
+        return PredictTimeRequestDto.builder()
+                .routeName(info.getShortLineName())
+                .startBusStopName(info.getBusstopName())
+                .arrivalBusStopName(arrivalBusStopName)
+                .routeInfos(list)
+                .build();
+    }
+}

--- a/src/main/java/capston/busthecall/manager/OpenApiManager.java
+++ b/src/main/java/capston/busthecall/manager/OpenApiManager.java
@@ -58,6 +58,20 @@ public class OpenApiManager {
     }
 
     private BusArrivalInfo parseBusArrivalInfo(JsonNode node) {
+        String routeName = node.path("SHORT_LINE_NAME").asText();
+
+        if (routeName.equals("진월07")) {
+            return BusArrivalInfo.builder()
+                    .busId(node.path("BUS_ID").asLong())
+                    .remainStop(node.path("REMAIN_STOP").asInt())
+                    .nowBusStopId(node.path("CURR_STOP_ID").asLong())
+                    .busstopName(node.path("BUSSTOP_NAME").asText())
+                    .shortLineName(routeName)
+                    .remainMin(node.path("REMAIN_MIN").asLong() * 60)
+                    .lineId(node.path("LINE_ID").asLong())
+                    .arriveFlag(node.path("ARRIVE_FLAG").asInt())
+                    .build();
+        }
         return BusArrivalInfo.builder()
                 .busId(node.path("BUS_ID").asLong())
                 .remainStop(node.path("REMAIN_STOP").asInt())

--- a/src/main/java/capston/busthecall/repository/BeaconRepository.java
+++ b/src/main/java/capston/busthecall/repository/BeaconRepository.java
@@ -3,8 +3,11 @@ package capston.busthecall.repository;
 import capston.busthecall.domain.Beacon;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface BeaconRepository extends JpaRepository<Beacon, Long> {
 
+    Optional<Beacon> findBeaconByStationId(Long stationId);
 
     Beacon findBeaconByUuId(String uuId);
 }

--- a/src/main/java/capston/busthecall/service/BeaconService.java
+++ b/src/main/java/capston/busthecall/service/BeaconService.java
@@ -25,6 +25,10 @@ public class BeaconService {
         return beacon.getStationId();
     }
 
+    public Beacon findOne(Long stationId) {
+        return beaconRepository.findBeaconByStationId(stationId).orElse(null);
+    }
+
     public List<Beacon> findAll() {
         return beaconRepository.findAll();
     }


### PR DESCRIPTION
AI 서버에 데이터 요청하기 위한 request body.
- Beacon 정류장 이름 추가.
- BusArrivalInfo stationId 추가. POST로 데이터 요청.
받은 데이터 적용시켜서 클라이언트에 응답.